### PR TITLE
Add Zabbix monitoring for FMN certificate age in days

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,12 +3,16 @@
 
 
 # Do we want to directly ship specific TLS certs ?
-# fedora-messaging pkgs already contains generic certs, but we can also have specific ones allowed for 
+# fedora-messaging pkgs already contains generic certs, but we can also have specific ones allowed for
 # some topics for pub/sub
-# These files should be in {{ pkistore }}/fedora-messaging 
+# These files should be in {{ pkistore }}/fedora-messaging
 fedora_messaging_tls_certs: False
-fedora_messaging_tls_cert: 
+fedora_messaging_tls_cert:
 fedora_messaging_tls_key:
 fedora_messaging_tls_ca:
 
-
+# Zabbix/monitoring part
+vdo_zabbix_templates:
+  - Template CentOS FMN consumer
+vdo_zabbix_groups:
+  - CentOS FMN consumers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,4 +16,10 @@
     - "{{ fedora_messaging_tls_cert }}"
     - "{{ fedora_messaging_tls_ca }}"
     - "{{ fedora_messaging_tls_key }}"
-  when: fedora_messaging_tls_certs  
+  when: fedora_messaging_tls_certs
+
+- name: Include monitoring if custom certs deployed
+  ansible.builtin.include_tasks: monitoring.yml
+  when: fedora_messaging_tls_certs
+  tags:
+    - monitoring

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -23,4 +23,3 @@
     name: FMN Cert monitoring
     job: /usr/lib/zabbix/zabbix-check-fmn-cert.sh
     minute: "0"
-    hour: "0"

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -1,0 +1,26 @@
+- name: Add host in Zabbix UI
+  block:
+  - name: Configuring agent in Zabbix server
+    delegate_to: "{{ zabbix_api_srv }}"
+    when: zabbix_api_srv is defined
+    ansible.builtin.include_role:
+      name: zabbix-server
+      tasks_from: agent_config
+      vars:
+        zabbix_templates: "{{ fmn_zabbix_templates }}"
+        zabbix_groups: "{{ fmn_zabbix_groups }}"
+    tags:
+    - monitoring
+
+- name: Zabbix check for FMN cert expiry
+  ansible.builtin.template:
+    src: zabbix-check-fmg-cert.sh.j2
+    dest: /usr/lib/zabbix/zabbix-check-fmn-cert.sh
+    mode: 0750
+
+- name: Zabbix cron jobs
+  ansible.builtin.cron:
+    name: FMN Cert monitoring
+    job: /usr/lib/zabbix/zabbix-check-fmn-cert.sh
+    minute: "0"
+    hour: "0"

--- a/templates/zabbix-check-fmg-cert.sh.j2
+++ b/templates/zabbix-check-fmg-cert.sh.j2
@@ -14,4 +14,4 @@ current_epoch=$(date +%s)
 # Calculate days left
 days_left=$(( (expiry_epoch - current_epoch) / 86400 ))
 
-echo $days_left
+zabbix_sender -c /etc/zabbix/zabbix_agentd.conf -k fmn.cert.days -o $days_left >/dev/null

--- a/templates/zabbix-check-fmg-cert.sh.j2
+++ b/templates/zabbix-check-fmg-cert.sh.j2
@@ -1,0 +1,17 @@
+#!/bin/bash
+# called by Zabbix to report days-left on the Fedora Messaging cert
+
+PATH=$PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+
+# Get the expiry date and convert to epoch seconds
+
+expiry_date=$(openssl x509 -text -in "/etc/fedora-messaging/{{ fedora_messaging_tls_cert }}" | grep "Not After" | sed 's/.*Not After : //')
+expiry_epoch=$(date -d "$expiry_date" +%s)
+
+# Get current time in epoch seconds
+current_epoch=$(date +%s)
+
+# Calculate days left
+days_left=$(( (expiry_epoch - current_epoch) / 86400 ))
+
+echo $days_left


### PR DESCRIPTION
This should deploy the necessary files to the FMN client to monitor it's cert - the cron job reports a number (in days) until expiry.

I've tested the script manually and it seems to work. The necessary Zabbix group/template has not been created yet, I can do that once we're happy with the Ansible side.

@arrfab how does this look to you?

Refs: https://gitlab.com/CentOS/infra/tracker/-/work_items/1736